### PR TITLE
Add error summary box and error message examples

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: d852f03a7d4666e81dddd187bc50ef65f7e668da
+  revision: 58054bbb4fbce04efe76573916f2d4c7d7cbb660
   specs:
     govuk_elements_form_builder (0.0.1)
       rails (~> 4.2)
@@ -120,7 +120,7 @@ GEM
       activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.1.1)
+    rake (11.1.2)
     rdoc (4.2.0)
       json (~> 1.4)
     ruby_parser (3.1.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,12 @@ class ApplicationController < ActionController::Base
   def home
     render 'home'
   end
+
+  def form_elements
+    render 'form_elements'
+  end
+
+  def error_validation
+    render 'error_validation'
+  end
 end

--- a/app/views/application/_helper_example.html.haml
+++ b/app/views/application/_helper_example.html.haml
@@ -1,20 +1,29 @@
 - example = ''
+- locales_config ||= nil
+- form_code ||= nil
+- code ||= nil
 
 %h3.heading-small{ id: "form-#{label.parameterize}" }= label
 
+- example += capture { eval(code.sub(/^- /,'').gsub("\n- ","\n") ) } if code
 = form_for(model.new) do |f|
-  - example = capture { eval(code) }
+  - example += capture { eval(form_code) } if form_code
 
   .example
-    = example
+    = example.html_safe
 
 %p code:
 %pre
   %code.language-ruby
-    = preserve do
-      :escaped
-        = form_for #{model.name.underscore} do |f|
-          - #{code}
+    - if code
+      = preserve do
+        :escaped
+          #{code}
+    - if form_code
+      = preserve do
+        :escaped
+          = form_for #{model.name.underscore} do |f|
+            - #{form_code}
 
 %p outputs:
 %pre

--- a/app/views/application/_helper_example.html.haml
+++ b/app/views/application/_helper_example.html.haml
@@ -3,7 +3,7 @@
 - form_code ||= nil
 - code ||= nil
 
-%h3.heading-small{ id: "form-#{label.parameterize}" }= label
+%h3.heading-medium{ id: "form-#{label.parameterize}" }= label
 
 - example += capture { eval(code.sub(/^- /,'').gsub("\n- ","\n") ) } if code
 = form_for(model.new) do |f|

--- a/app/views/application/error_validation.html.haml
+++ b/app/views/application/error_validation.html.haml
@@ -1,0 +1,39 @@
+- @page_title = 'Examples'
+
+%h1.heading-xlarge
+  %span.heading-secondary
+    GOV.UK elements
+  Errors and validation
+
+%p.lede
+  Use
+  = link_to 'form builder', root_path
+  helper methods to develop form-based applications.
+
+%h2.heading-small.heading-contents Contents:
+.grid-row
+  .column-two-thirds
+    %ul.list.list-contents
+      %li
+        %a{ href: '#form-error-summary-box' } Error summary box
+      %li
+        %a{ href: '#form-error-validation' } Error validation
+
+= render partial: 'helper_example',
+      locals: { label: 'Error summary box',
+                code: ['- person = Person.new',
+                  '- person.valid?',
+                  %'- GovukElementsErrorsHelper.error_summary person,\n  "Message to alert the user to a problem goes here",\n  "Optional description of the errors and how to correct them"'].join("\n"),
+                model: Person }
+
+= render partial: 'helper_example',
+      locals: { label: 'Error validation',
+                form_code: 'f.object.valid?; f.text_field :name',
+                model: Person,
+                locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
+
+.grid-row.divider
+  .column-two-thirds
+    %p
+      Back to
+      = link_to 'form builder examples index', root_path

--- a/app/views/application/form_elements.html.haml
+++ b/app/views/application/form_elements.html.haml
@@ -1,0 +1,38 @@
+- @page_title = 'Examples'
+
+%h1.heading-xlarge
+  %span.heading-secondary
+    GOV.UK elements
+  Form elements
+
+%p.lede
+  Use
+  = link_to 'form builder', root_path
+  helper methods to develop form-based applications.
+
+%h2.heading-small.heading-contents Contents:
+.grid-row
+  .column-two-thirds
+    %ul.list.list-contents
+      %li
+        %a{ href: '#form-text-fields' } Text fields
+      %li
+        %a{ href: '#form-hint-text' } Hint text
+
+= render partial: 'helper_example',
+      locals: { label: 'Text fields',
+                form_code: 'f.text_field :name',
+                model: Person,
+                locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
+
+= render partial: 'helper_example',
+      locals: { label: 'Hint text',
+                form_code: 'f.text_field :ni_number',
+                model: Person,
+                locales_config: "en:\n  helpers:\n    label:\n      person:\n        ni_number: National Insurance number\n    hint:\n      person:\n        ni_number: It’ll be on your last payslip. For example, JH 21 90 0A." }
+
+.grid-row.divider
+  .column-two-thirds
+    %p
+      Back to
+      = link_to 'form builder examples index', root_path

--- a/app/views/application/home.html.haml
+++ b/app/views/application/home.html.haml
@@ -4,50 +4,30 @@
   %span.heading-secondary GOV.UK elements
   Rails form builder examples
 
-%p.lede.text
-  Use
-  = link_to 'GOV.UK elements form builder', 'https://github.com/ministryofjustice/govuk_elements_form_builder'
+%p.lede
+  Use form builder
   helper methods to develop form-based applications in Ruby on Rails.
 
-%h2.heading-small.heading-contents Contents:
 .grid-row
+  .column-one-third
+    %h2.heading-medium
+      = link_to 'Form elements', form_elements_path
+    %p
+      Form fields, labels, focus states, radio buttons, checkboxes.
+  .column-one-third
+    %h2.heading-medium
+      = link_to 'Errors and validation', error_validation_path
+    %p
+      Summary boxes, highlighting errors in forms.
+  .column-one-third
+
+.grid-row.divider
   .column-two-thirds
-    %ul.list.list-contents
-      %li
-        %a{ href: '#form-text-fields' } Text fields
-      %li
-        %a{ href: '#form-hint-text' } Hint text
-      %li
-        %a{ href: '#form-error-summary-box' } Error summary box
-
-= render partial: 'helper_example',
-      locals: { label: 'Text fields',
-                form_code: 'f.text_field :name',
-                model: Person,
-                locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
-
-= render partial: 'helper_example',
-      locals: { label: 'Hint text',
-                form_code: 'f.text_field :ni_number',
-                model: Person,
-                locales_config: "en:\n  helpers:\n    label:\n      person:\n        ni_number: National Insurance number\n    hint:\n      person:\n        ni_number: It’ll be on your last payslip. For example, JH 21 90 0A." }
-
-= render partial: 'helper_example',
-      locals: { label: 'Error summary box',
-                code: ['- person = Person.new',
-                  '- person.valid?',
-                  %'- GovukElementsErrorsHelper.error_summary person,\n  "Message to alert the user to a problem goes here",\n  "Optional description of the errors and how to correct them"'].join("\n"),
-                model: Person }
-
-= render partial: 'helper_example',
-      locals: { label: 'Error validation',
-                form_code: 'f.object.valid?; f.text_field :name',
-                model: Person,
-                locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
-
-= # render partial: 'helper_example',
-      locals: { label: 'Textarea inputs', code: 'f.text_area :name' }
-
-= # render partial: 'helper_example',
-      locals: { label: 'Radio buttons',
-        code: "f.radio_buttons(:status, %i[ accepted declined ], inline: true, labeler: ->(v){ t(v, scope: 'invitations.statuses') })" }
+    %h3.heading-small
+      Looking for the software code?
+    %p
+      The source code for <a href="https://github.com/ministryofjustice/govuk_elements_form_builder" rel="external">form builder can be found on GitHub</a>.
+    %h3.heading-small
+      Want to discuss these helpers?
+    %p
+      <a href="https://github.com/ministryofjustice/govuk_elements_form_builder/issues" rel="external">Raise an issue on our GitHub repo</a>.

--- a/app/views/application/home.html.haml
+++ b/app/views/application/home.html.haml
@@ -17,18 +17,33 @@
         %a{ href: '#form-text-fields' } Text fields
       %li
         %a{ href: '#form-hint-text' } Hint text
+      %li
+        %a{ href: '#form-error-summary-box' } Error summary box
 
 = render partial: 'helper_example',
       locals: { label: 'Text fields',
-                code: 'f.text_field :name',
+                form_code: 'f.text_field :name',
                 model: Person,
                 locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
 
 = render partial: 'helper_example',
       locals: { label: 'Hint text',
-                code: 'f.text_field :ni_number',
+                form_code: 'f.text_field :ni_number',
                 model: Person,
                 locales_config: "en:\n  helpers:\n    label:\n      person:\n        ni_number: National Insurance number\n    hint:\n      person:\n        ni_number: It’ll be on your last payslip. For example, JH 21 90 0A." }
+
+= render partial: 'helper_example',
+      locals: { label: 'Error summary box',
+                code: ['- person = Person.new',
+                  '- person.valid?',
+                  %'- GovukElementsErrorsHelper.error_summary person,\n  "Message to alert the user to a problem goes here",\n  "Optional description of the errors and how to correct them"'].join("\n"),
+                model: Person }
+
+= render partial: 'helper_example',
+      locals: { label: 'Error validation',
+                form_code: 'f.object.valid?; f.text_field :name',
+                model: Person,
+                locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
 
 = # render partial: 'helper_example',
       locals: { label: 'Textarea inputs', code: 'f.text_area :name' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
 
   root 'application#home'
+  get 'form-elements' => 'application#form_elements', as: :form_elements
+  get 'error-validation' => 'application#error_validation', as: :error_validation
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
Separate pages for error validation and form element examples.

Change homepage to be an index that links to a separate error validation page and a separate form elements page.
