### PR TITLE
Add text field example for nested model with fields_for

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: 58054bbb4fbce04efe76573916f2d4c7d7cbb660
+  revision: 2de60668574a6ffe5bba051d56b3343c5c8ade68
   specs:
     govuk_elements_form_builder (0.0.1)
       rails (~> 4.2)

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,8 @@
+class Address
+  include ActiveModel::Model
+
+  attr_accessor :address
+  attr_accessor :postcode
+  validates_presence_of :postcode
+
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,4 +5,9 @@ class Person
   validates_presence_of :name
 
   attr_accessor :ni_number
+  attr_accessor :address
+
+  def address_attributes=(attributes)
+    @address = Address.new(attributes)
+  end
 end

--- a/app/views/application/_helper_example.html.haml
+++ b/app/views/application/_helper_example.html.haml
@@ -5,20 +5,24 @@
 
 %h3.heading-medium{ id: "form-#{label.parameterize}" }= label
 
-- example += capture { eval(code.sub(/^- /,'').gsub("\n- ","\n") ) } if code
-= form_for(model.new) do |f|
-  - example += capture { eval(form_code) } if form_code
+- example += capture { eval(code.sub(/^- /,'').gsub("\n- ","\n") ) }.to_s + "\n" if code
+- eval(code.sub(/^- /,'').gsub("\n- ","\n") ) if code
+- person ||= model.new
+= form_for(person) do |f|
+  - example += capture { eval(form_code) }.to_s if form_code
 
   .example
     = example.html_safe
 
 %p code:
-%pre
-  %code.language-ruby
-    - if code
+- if code
+  %pre
+    %code.language-ruby
       = preserve do
         :escaped
           #{code}
+%pre
+  %code.language-ruby
     - if form_code
       = preserve do
         :escaped

--- a/app/views/application/form_elements.html.haml
+++ b/app/views/application/form_elements.html.haml
@@ -20,6 +20,10 @@
         %a{ href: '#form-hint-text' } Hint text
       %li
         %a{ href: '#form-text-fields-for-nested-model' } Text fields for nested model
+      %li
+        See also
+        %a{ href: '/error-validation' } errors and validation
+        page
 
 = render partial: 'helper_example',
       locals: { label: 'Text fields',

--- a/app/views/application/form_elements.html.haml
+++ b/app/views/application/form_elements.html.haml
@@ -18,6 +18,8 @@
         %a{ href: '#form-text-fields' } Text fields
       %li
         %a{ href: '#form-hint-text' } Hint text
+      %li
+        %a{ href: '#form-text-fields-for-nested-model' } Text fields for nested model
 
 = render partial: 'helper_example',
       locals: { label: 'Text fields',
@@ -30,6 +32,14 @@
                 form_code: 'f.text_field :ni_number',
                 model: Person,
                 locales_config: "en:\n  helpers:\n    label:\n      person:\n        ni_number: National Insurance number\n    hint:\n      person:\n        ni_number: It’ll be on your last payslip. For example, JH 21 90 0A." }
+
+= render partial: 'helper_example',
+      locals: { label: 'Text fields for nested model',
+                code: ['- person = Person.new',
+                  "- person.address = Address.new\n"].join("\n"),
+                form_code: 'f.fields_for(:address) { |a| a.text_field :postcode }',
+                model: Person,
+                locales_config: "en:\n  helpers:\n    label:\n      person[address_attributes]:\n        postcode: UK postcode" }
 
 .grid-row.divider
   .column-two-thirds

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
       person:
         name: Full name
         ni_number: National Insurance number
+      person[address_attributes]:
+        postcode: UK postcode
     hint:
       person:
         ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.


### PR DESCRIPTION
Show how the text_field helper works when called inside of fields_for to generate an input field for an attribute on a nested model.

Show how to change the label text for the nested model by setting a label in the locales en.yml file.

Closes #5
