### PR TITLE
Add `radio_button_fieldset` stacked/inline radio button examples

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: 2de60668574a6ffe5bba051d56b3343c5c8ade68
+  revision: a27312323e4004d0cfc72083ec576d3215019e73
   specs:
     govuk_elements_form_builder (0.0.1)
       rails (~> 4.2)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+
+  def format_html_example html
+    "\n" + html.
+      gsub('><', ">\n  <").
+      gsub('  </', '</').
+      gsub(%r[</span>\n</(label|legend)>], '</span></\1>').
+      gsub("\n<label", "\n  <label").
+      gsub(%r[<input(.+)</label>]) { "  <input#{$1}\n  </label>" }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,10 @@ module ApplicationHelper
       gsub("\n<label", "\n  <label").
       gsub(%r[<input(.+)</label>]) { "  <input#{$1}\n  </label>" }
   end
+
+  def format_form_code form_code
+    form_code.
+      sub(',', ",\n     ").
+      gsub(', :', ",\n          :")
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,11 +1,13 @@
 class Person
   include ActiveModel::Model
 
-  attr_accessor :name
-  validates_presence_of :name
-
-  attr_accessor :ni_number
   attr_accessor :address
+  attr_accessor :has_user_account
+  attr_accessor :location
+  attr_accessor :name
+  attr_accessor :ni_number
+
+  validates_presence_of :name
 
   def address_attributes=(attributes)
     @address = Address.new(attributes)

--- a/app/views/application/_helper_example.html.haml
+++ b/app/views/application/_helper_example.html.haml
@@ -33,7 +33,7 @@
 %pre
   %code.language-markup
     = preserve do
-      #{"\n" + example.gsub('><', ">\n  <").gsub('  </', '</') }
+      #{format_html_example(example)}
 
 - if locales_config
   %p locales file:

--- a/app/views/application/_helper_example.html.haml
+++ b/app/views/application/_helper_example.html.haml
@@ -14,31 +14,37 @@
   .example
     = example.html_safe
 
-%p code:
-- if code
-  %pre
-    %code.language-ruby
-      = preserve do
-        :escaped
-          #{code}
-%pre
-  %code.language-ruby
+.grid-row
+  %div{ class: locales_config.present? ? 'column-one-half' : '' }
+
+    %p code:
+    - if code
+      %pre
+        %code.language-ruby
+          = preserve do
+            :escaped
+              #{code}
+
     - if form_code
-      = preserve do
-        :escaped
-          = form_for #{model.name.underscore} do |f|
-            - #{form_code}
+      %pre
+        %code.language-ruby
+          = preserve do
+            :escaped
+              = form_for #{model.name.underscore} do |f|
+                - #{format_form_code(form_code)}
 
-%p outputs:
-%pre
-  %code.language-markup
-    = preserve do
-      #{format_html_example(example)}
+  .column-one-half
+    - if locales_config
+      %p locales file:
+      %pre
+        %code.language-yaml
+          = preserve do
+            :escaped
+              #{locales_config}
 
-- if locales_config
-  %p locales file:
+.grid-row
+  %p outputs:
   %pre
-    %code.language-yaml
+    %code.language-markup
       = preserve do
-        :escaped
-          #{locales_config}
+        #{format_html_example(example)}

--- a/app/views/application/error_validation.html.haml
+++ b/app/views/application/error_validation.html.haml
@@ -28,7 +28,9 @@
 
 = render partial: 'helper_example',
       locals: { label: 'Error validation',
-                form_code: 'f.object.valid?; f.text_field :name',
+                code: ['- person = Person.new',
+                  '- person.valid?'].join("\n"),
+                form_code: 'f.text_field :name',
                 model: Person,
                 locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
 

--- a/app/views/application/form_elements.html.haml
+++ b/app/views/application/form_elements.html.haml
@@ -21,6 +21,10 @@
       %li
         %a{ href: '#form-text-fields-for-nested-model' } Text fields for nested model
       %li
+        %a{ href: '#form-inline-radio-buttons' } Inline radio buttons
+      %li
+        %a{ href: '#form-stacked-radio-buttons' } Stacked radio buttons
+      %li
         See also
         %a{ href: '/error-validation' } errors and validation
         page
@@ -44,6 +48,18 @@
                 form_code: 'f.fields_for(:address) { |a| a.text_field :postcode }',
                 model: Person,
                 locales_config: "en:\n  helpers:\n    label:\n      person[address_attributes]:\n        postcode: UK postcode" }
+
+= render partial: 'helper_example',
+      locals: { label: 'Inline radio buttons',
+                form_code: 'f.radio_button_fieldset :has_user_account, inline: true',
+                model: Person,
+                locales_config: "en:\n  helpers:\n    fieldset:\n      person:\n        has_user_account: Do you already have a personal user account?\n" }
+
+= render partial: 'helper_example',
+      locals: { label: 'Stacked radio buttons',
+                form_code: 'f.radio_button_fieldset :location, choices: [:ni, :isle_of_man_channel_islands, :british_abroad]',
+                model: Person,
+                locales_config: "en:\n  helpers:\n    fieldset:\n      person:\n        location: Where do you live?\n    label:\n      person:\n        location:\n          ni: Northern Ireland\n          isle_of_man_channel_islands: Isle of Man or Channel Islands\n          british_abroad: I am a British citizen living abroad\n    hint:\n      person:\n        location: Select from these options because you answered you do not reside in England, Wales, or Scotland\n" }
 
 .grid-row.divider
   .column-two-thirds

--- a/app/views/application/form_elements.html.haml
+++ b/app/views/application/form_elements.html.haml
@@ -39,7 +39,7 @@
       locals: { label: 'Hint text',
                 form_code: 'f.text_field :ni_number',
                 model: Person,
-                locales_config: "en:\n  helpers:\n    label:\n      person:\n        ni_number: National Insurance number\n    hint:\n      person:\n        ni_number: It’ll be on your last payslip. For example, JH 21 90 0A." }
+                locales_config: "en:\n  helpers:\n    label:\n      person:\n        ni_number: National Insurance number\n    hint:\n      person:\n        ni_number: |\n          It’ll be on your last payslip. For example, JH 21 90 0A." }
 
 = render partial: 'helper_example',
       locals: { label: 'Text fields for nested model',
@@ -53,13 +53,13 @@
       locals: { label: 'Inline radio buttons',
                 form_code: 'f.radio_button_fieldset :has_user_account, inline: true',
                 model: Person,
-                locales_config: "en:\n  helpers:\n    fieldset:\n      person:\n        has_user_account: Do you already have a personal user account?\n" }
+                locales_config: "en:\n  helpers:\n    fieldset:\n      person:\n        has_user_account: |\n          Do you already have a personal user account?\n" }
 
 = render partial: 'helper_example',
       locals: { label: 'Stacked radio buttons',
                 form_code: 'f.radio_button_fieldset :location, choices: [:ni, :isle_of_man_channel_islands, :british_abroad]',
                 model: Person,
-                locales_config: "en:\n  helpers:\n    fieldset:\n      person:\n        location: Where do you live?\n    label:\n      person:\n        location:\n          ni: Northern Ireland\n          isle_of_man_channel_islands: Isle of Man or Channel Islands\n          british_abroad: I am a British citizen living abroad\n    hint:\n      person:\n        location: Select from these options because you answered you do not reside in England, Wales, or Scotland\n" }
+                locales_config: "en:\n  helpers:\n    fieldset:\n      person:\n        location: Where do you live?\n    label:\n      person:\n        location:\n          ni: |\n            Northern Ireland\n          isle_of_man_channel_islands: |\n            Isle of Man or Channel Islands\n          british_abroad: |\n            I am a British citizen living abroad\n    hint:\n      person:\n        location: Select from these options because you answered you do not reside in England, Wales, or Scotland\n" }
 
 .grid-row.divider
   .column-two-thirds

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,12 +22,21 @@
 en:
   hello: "Hello world"
   helpers:
+    fieldset:
+      person:
+        location: Where do you live?
+        has_user_account: Do you already have a personal user account?
     label:
       person:
+        location:
+          ni: Northern Ireland
+          isle_of_man_channel_islands: Isle of Man or Channel Islands
+          british_abroad: I am a British citizen living abroad
         name: Full name
         ni_number: National Insurance number
       person[address_attributes]:
         postcode: UK postcode
     hint:
       person:
+        location: Select from these options because you answered you do not reside in England, Wales, or Scotland
         ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,13 +25,17 @@ en:
     fieldset:
       person:
         location: Where do you live?
-        has_user_account: Do you already have a personal user account?
+        has_user_account: |
+          Do you already have a personal user account?
     label:
       person:
         location:
-          ni: Northern Ireland
-          isle_of_man_channel_islands: Isle of Man or Channel Islands
-          british_abroad: I am a British citizen living abroad
+          ni: |
+            Northern Ireland
+          isle_of_man_channel_islands: |
+            Isle of Man or Channel Islands
+          british_abroad: |
+            I am a British citizen living abroad
         name: Full name
         ni_number: National Insurance number
       person[address_attributes]:
@@ -39,4 +43,5 @@ en:
     hint:
       person:
         location: Select from these options because you answered you do not reside in England, Wales, or Scotland
-        ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.
+        ni_number: |
+          It’ll be on your last payslip. For example, JH 21 90 0A.


### PR DESCRIPTION
Add example for `radio_button_fieldset` producing inline radio buttons.

Add example for `radio_button_fieldset` producing stacked radio buttons.

Add examples for setting legend, hint, and label text via locales file.

Display code example in column beside locales file example.

Closes #6
