### PR TITLE
Move custom class example to second example

### DIFF
--- a/app/views/application/form_elements.html.haml
+++ b/app/views/application/form_elements.html.haml
@@ -33,13 +33,13 @@
 
 = render partial: 'helper_example',
       locals: { label: 'Text fields',
-                form_code: 'f.text_field :name, {}, class: "my-class"',
+                form_code: 'f.text_field :name',
                 model: Person,
                 locales_config: "en:\n  helpers:\n    label:\n      person:\n        name: Full name" }
 
 = render partial: 'helper_example',
       locals: { label: 'Hint text',
-                form_code: 'f.text_field :ni_number',
+                form_code: 'f.text_field :ni_number, class: "my-class"',
                 model: Person,
                 locales_config: "en:\n  helpers:\n    label:\n      person:\n        ni_number: National Insurance number\n    hint:\n      person:\n        ni_number: |\n          It’ll be on your last payslip. For example, JH 21 90 0A." }
 


### PR DESCRIPTION
Keep first example simple by moving the custom class example to second example.
