### PR TITLE
update bundler and two other gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,15 +58,12 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
-    concurrent-ruby (1.0.5-java)
+    crass (1.0.4)
     debug_inspector (0.0.2)
     diff-lcs (1.3)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
-    ffi (1.9.18-java)
-    ffi (1.9.18-x64-mingw32)
-    ffi (1.9.18-x86-mingw32)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk_elements_form_builder (0.0.3)
@@ -91,7 +88,8 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    loofah (2.0.3)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
@@ -99,18 +97,12 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
     multi_json (1.12.1)
     nio4r (2.0.0)
-    nio4r (2.0.0-java)
-    nokogiri (1.7.0.1)
-      mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.0.1-java)
-    nokogiri (1.7.0.1-x64-mingw32)
-      mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.0.1-x86-mingw32)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     pg (0.19.0)
     prism-rails (1.6.0.3)
       railties (>= 4.2, < 6)
@@ -118,16 +110,10 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry (0.10.4-java)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-      spoon (~> 0.0)
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
     puma (3.8.2)
-    puma (3.8.2-java)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -202,8 +188,6 @@ GEM
       railties (>= 3.1)
       slim (~> 3.0)
     slop (3.6.0)
-    spoon (0.0.6)
-      ffi
     spring (2.0.1)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -219,7 +203,6 @@ GEM
     temple (0.7.7)
     thor (0.19.4)
     thread_safe (0.3.6)
-    thread_safe (0.3.6-java)
     tilt (2.0.6)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
@@ -235,11 +218,12 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-driver (0.6.5-java)
-      websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+
+PLATFORMS
+  ruby
 
 DEPENDENCIES
   byebug
@@ -274,4 +258,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.4
+   1.16.0


### PR DESCRIPTION
Addresses some issues Heroku raised with the older bundler version.

I also updated nokogiri and loofah to resolve the security vulnerabilities raised by Github